### PR TITLE
change of FakeCPUID

### DIFF
--- a/config.plist
+++ b/config.plist
@@ -146,7 +146,7 @@
 		<key>Debug</key>
 		<false/>
 		<key>FakeCPUID</key>
-		<string>0x0506E3</string>
+		<string>0x0106E0</string>
 		<key>KernelCpu</key>
 		<false/>
 		<key>KernelLapic</key>


### PR DESCRIPTION
Allows installation on older Hardware, like Mid 2011 Mac minis.
Fixes "pid 1 exited -- exit reason namespace 2 subcode 0x4" crash after first Mojave install.