### PR TITLE
README updated with 'Installation Not Starting' issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Some available commands:
 * Installation Loop
   * Q: After starting the installation the VM restarts and I see the installer again.
   * A: You've to press enter in the terminal after the installer restarts.
+* Installation Not Starting
+  * Q: I've pressed ```Continue``` to start the installation and nothing happens for minutes.
+  * A: Your macOS installer might be incomplete or corrupted, please download it again from Apple.
 * Error Message
   * Q: I get the error code 2, 3, 4, or 6.
   * A: You need to have some software components installed on your machine (VirtualBox, VirtualBox Extension Pack, awk). If you've installed [Homebrew](https://brew.sh), the script will partly install these automatically. Otherwise, you need to install them manually.


### PR DESCRIPTION
Hi and thanks for this wonderful script!

Installing macOS 10.15 Catalina worked without a hitch for me, but I had this issue with installing 10.14 Mojave, for which I found a solution was to get the installer again (after wasting quite some time waiting for the installation to proceed + trying other ways.)

For reference:

```
$ du -msc Install\ macOS\ Mojave.app.bad/ /Applications/Install\ macOS\ Mojave.app/
5786 Install macOS Mojave.app.bad/
5789 /Applications/Install macOS Mojave.app/
```

Hope it helps!