### PR TITLE
Use destination folder when creating VM

### DIFF
--- a/runMacOSVirtualbox.sh
+++ b/runMacOSVirtualbox.sh
@@ -272,7 +272,7 @@ createVM() {
   info "Creating VM '$VM_NAME' (around 2 seconds)..." 99
   if ! VBoxManage showvminfo "$VM_NAME" >/dev/null 2>&1; then
     result "."
-    VBoxManage createvm --register --name "$VM_NAME" --ostype MacOS1013_64
+    VBoxManage createvm --register --name "$VM_NAME" --basefolder "$DST_DIR" --ostype MacOS1013_64
     VBoxManage modifyvm "$VM_NAME" --usbxhci on --memory "$VM_RAM" --vram "$VM_VRAM" --cpus "$VM_CPU" --firmware efi --chipset ich9 --mouse usbtablet --keyboard usb
     VBoxManage setextradata "$VM_NAME" "CustomVideoMode1" "${VM_RES}x32"
     VBoxManage setextradata "$VM_NAME" VBoxInternal2/EfiGraphicsResolution "$VM_RES"


### PR DESCRIPTION
The command to create the VM was missing the --basefolder argument.

When a custom destination folder has been specified using the `DST_DIR` environment variable the VM itself was still created in the default folder (`$HOME/VirtualBox VMs`).