### PR TITLE
Increase installer volume size to 16Gb

### DIFF
--- a/runMacOSVirtualbox.sh
+++ b/runMacOSVirtualbox.sh
@@ -163,7 +163,7 @@ createImage() {
     result "."
     ejectAll
     mkdir -p "$DST_DIR"
-    hdiutil create -o "$DST_DMG" -size 10g -layout SPUD -fs HFS+J &&
+    hdiutil create -o "$DST_DMG" -size 16g -layout SPUD -fs HFS+J &&
     hdiutil attach "$DST_DMG" -mountpoint "$DST_VOL" &&
     sudo "$INST_BIN" --nointeraction --volume "$DST_VOL" --applicationpath "$INST_VER" ||
     error "Could create or run installer. Please look in the log file..."


### PR DESCRIPTION
BigSur requires about 16Gb for installer

Resolves #115 